### PR TITLE
add svelte field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "module": "dist/esm/index.js",
   "unpkg": "dist/iife/index.js",
   "typings": "dist/index.d.ts",
+  "svelte": "src/index.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Working on my PC with `npm link` SvelteKit and Vite complained with this error:

![image](https://user-images.githubusercontent.com/41120635/129051948-3043de72-0ffe-4d53-a2d2-3e561d511094.png)

Adding the "svelte" field fixes this.