### PR TITLE
fix: make work with svelte 5 runes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "swrev": "^4.0.0"
   },
   "devDependencies": {
-    "svelte": "^4.2.8",
+    "svelte": "^5.0.0",
     "typescript": "^5.3.3",
-    "vite": "^5.0.10"
+    "vite": "^6.0.0"
   },
   "peerDependencies": {
-    "svelte": "^4.0.0 || ^5.0.0-next.0"
+    "svelte": "^4.0.0 || ^5.0.0"
   }
 }

--- a/src/sswr.ts
+++ b/src/sswr.ts
@@ -7,7 +7,7 @@ import {
   SWRRevalidateOptions,
   CacheClearOptions,
 } from 'swrev'
-import { onDestroy, beforeUpdate } from 'svelte'
+import { onDestroy } from 'svelte'
 import { writable, derived } from 'svelte/store'
 
 /**
@@ -25,26 +25,21 @@ export class SSWR extends SWR {
     const data = writable<D | undefined>(undefined, () => () => unsubscribe?.())
     const error = writable<E | undefined>(undefined, () => () => unsubscribe?.())
 
-    // Stores the unsubscription handler
-    beforeUpdate(() => {
-      // Handlers that will be executed when data changes.
-      const onData = (d: D) => {
-        // Set the last error to undefined
-        // since we just got a correct data.
-        error.set(undefined)
-        // Set the data's value to the new value.
-        data.set(d)
-      }
-      const onError = (e: E) => error.set(e)
+    // Handlers that will be executed when data changes.
+    const onData = (d: D) => {
+      // Set the last error to undefined
+      // since we just got a correct data.
+      error.set(undefined)
+      // Set the data's value to the new value.
+      data.set(d)
+    }
+    const onError = (e: E) => error.set(e)
 
-      // Subscribe and use the SWR fetch using the given key.
-      if (!unsubscribe) {
-        unsubscribe = this.subscribe<D, E>(key, onData, onError, {
-          loadInitialCache: true,
-          ...options,
-        }).unsubscribe
-      }
-    })
+    // Subscribe and use the SWR fetch using the given key.
+    unsubscribe = this.subscribe<D, E>(key, onData, onError, {
+      loadInitialCache: true,
+      ...options,
+    }).unsubscribe
 
     // Cleanup code to unsubscribe.
     onDestroy(() => unsubscribe?.())


### PR DESCRIPTION
This PR removes the use of beforeUpdate.

`beforeUpdate` is deprecated in Svelte 5 and cannot be used in runes mode.

The docs suggest using $effect.pre, but this can't be used outside of components. 