### PR TITLE
fix `repository` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sswr",
   "version": "2.1.0",
   "description": "Svelte stale while revalidate (SWR) data fetching strategy",
-  "repository": "github.com/ConsoleTVs/sswr",
+  "repository": "https://github.com/ConsoleTVs/sswr",
   "author": "Èrik C. Forés",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
This package can be found on [svelte.dev/packages](https://svelte.dev/packages) now. However, the `repository` field is incorrectly formatted in `package.json`, so links to the repo on svelte.dev/packages link to `https://svelte.dev/github.com/ConsoleTVs/sswr` instead of `https://github.com/ConsoleTVs/sswr`. This should fix that. 