### PR TITLE
fix: add npm bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.1.0",
   "description": "Svelte stale while revalidate (SWR) data fetching strategy",
   "repository": "https://github.com/ConsoleTVs/sswr",
+  "bugs": {
+    "url": "https://github.com/ConsoleTVs/sswr/issues"
+  },
   "author": "Èrik C. Forés",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Add npm `bugs` metadata to point consumers to the repository issue tracker.

## Validation
- `node -e "const p=require('./package.json'); if(p.name!=='sswr') throw new Error('wrong package'); if(!p.bugs || p.bugs.url!=='https://github.com/ConsoleTVs/sswr/issues') throw new Error('missing bugs'); console.log(JSON.stringify({name:p.name,version:p.version,bugs:p.bugs}))"`
- `git diff --check`
- `npm pack --dry-run --json --ignore-scripts`