### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "sswr",
   "version": "2.1.0",
+  "bugs": {
+    "url": "https://github.com/ConsoleTVs/sswr/issues"
+  },
   "description": "Svelte stale while revalidate (SWR) data fetching strategy",
   "repository": "https://github.com/ConsoleTVs/sswr",
   "author": "Èrik C. Forés",


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.